### PR TITLE
Build + Test Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 soon^TM
 
-
 [did you see the CLI?](./ts/sdk/README.md) and the [wiki?](https://github.com/drift-labs/drift-vaults/wiki)
-
 
 # Development
 
@@ -28,11 +26,14 @@ rustup override set 1.70.0
 sh -c "$(curl -sSfL https://release.solana.com/v1.16.27/install)"
 ```
 
-If on Mac and getting this error: 
+If on Mac and getting this error:
+
 ```shell
 Error: failed to start validator: Failed to create ledger at test-ledger: blockstore error
 ```
+
 then run these commands:
+
 ```shell
 brew install gnu-tar
 # Put this in ~/.zshrc 
@@ -40,8 +41,16 @@ export PATH="/opt/homebrew/opt/gnu-tar/libexec/gnubin:$PATH"
 ```
 
 ## Run tests
+
 ```shell
 yarn && cd ts/sdk && yarn && yarn build && cd ..
 
 export ANCHOR_WALLET=~/.config/solana/id.json && anchor test
+```
+
+For ease-of-use you can run the following script to build and test instead:
+
+```shell
+chmod +x ./test.sh
+./test.sh
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,42 @@
+home() {
+    cd "$(git rev-parse --show-toplevel)" || exit 1
+}
+
+# return root level of the git repo
+home
+
+if [[ $(uname -m) == "arm64" ]]; then
+    echo "Running on Apple Silicon, using x86-64 toolchain"
+    rustup override set 1.70.0-x86_64-apple-darwin
+else
+    rustup override set 1.70.0
+fi
+
+# check that "solana" returns output from the command line
+solana_cli_exists=$(solana --version)
+if [[ -z $solana_cli_exists ]]; then
+    echo "Installing Solana CLI..."
+    sh -c "$(curl -sSfL https://release.solana.com/v1.16.27/install)" || exit 1
+fi
+
+avm_cli_exists=$(avm --version)
+if [[ -z $avm_cli_exists ]]; then
+    echo "Please install Anchor here: https://book.anchor-lang.com/getting_started/installation.html"
+    exit 1
+fi
+
+solana-install init 1.16.27
+
+avm use 0.29.0
+
+cargo build || exit 1
+
+anchor build || exit 1
+
+cargo fmt || exit 1
+
+yarn && cd ts/sdk && yarn && yarn build || exit 1
+
+home
+
+yarn prettify:fix || exit 1

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+detach=false
+no_test=false
+no_build=false
+
+usage() {
+  if [[ -n $1 ]]; then
+    echo "$*"
+    echo
+  fi
+  cat <<EOF
+
+usage: $0 [OPTIONS]
+
+OPTIONS:
+  --detach             - Once bootstrap and tests are complete, keep the validator running
+  --no-test            - Skip running tests and only bootstrap the validator
+  --no-build           - Skip building the project
+
+EOF
+  exit 1
+}
+
+positional_args=()
+while [[ -n $1 ]]; do
+  if [[ ${1:0:1} = - ]]; then
+    if [[ $1 = --detach ]]; then
+      detach=true
+      shift 1
+    elif [[ $1 = --no-test ]]; then
+      no_test=true
+      shift 1
+    elif [[ $1 = --no-build ]]; then
+      no_build=true
+      shift 1
+    elif [[ $1 = -h ]]; then
+      usage "$@"
+    else
+      echo "Unknown argument: $1"
+      exit 1
+    fi
+  else
+    positional_args+=("$1")
+    shift
+  fi
+done
+
+kill_process() {
+    # Kills solana validator if running
+    solana_pid=$(pgrep -f solana)
+    if [[ -n $solana_pid ]]; then
+        pkill -f solana
+    fi
+    # exit shell script with success status
+    exit 0
+}
+# ctrl+c or similar signals are caught in this "trap" which will execute "kill_process" function
+trap kill_process SIGINT
+
+# helper function to silence output from whichever process proceeds this function
+bkg() { "$@" >/dev/null & }
+
+if [[ $no_build == false ]]; then
+  chmod +x ./build.sh
+  ./build.sh
+fi
+
+# Kill solana validator if running
+solana_pid=$(pgrep -f solana)
+if [[ -n $solana_pid ]]; then
+  pkill -f solana
+fi
+
+# start anchor localnet in background
+# "bkg" suppresses validator output to build/test output aren't hard to find
+bkg anchor localnet
+# warm up validator (spurious errors may occur if this is not done)
+sleep 5
+
+# if network bootstrap is required, such as admin-level instructions or minting tokens, then do that here.
+
+
+export ANCHOR_WALLET="$HOME/.config/solana/id.json"
+if [[ $no_test == false ]]; then
+  yarn anchor-tests
+fi
+
+# if --detach is not given, then the test is killed once "yarn anchor-tests" completes
+# otherwise the validator continues to run
+# passing --detach has the same effect as running "anchor test --detach"
+if [[ $detach == false ]]; then
+    kill_process
+else
+    echo "Validator still running..."
+fi
+
+# required for signal trap to work
+while true; do
+    sleep 1
+done


### PR DESCRIPTION
`build.sh` does the following:
* install Solana if needed, and link to Anchor install if needed
* set Anchor, Solana, and Rust toolchain versions
* compile Rust and Typescript
* format Rust and Typescript

`test.sh` does the following:
* calls `build.sh`
* starts an anchor localnet in the background and suppresses output
* sets ANCHOR_WALLET to Anchor.toml keypair path
* runs anchor test script
* keeps validator alive if given `--detach`
* skips building if given `--no-build`
* skips tests if given `--no-test`
* "traps" (listens) fo SIGINT and shuts down localnet PID and test PID if needed