### PR TITLE
Update withdraw command to use 'shares' parameter

### DIFF
--- a/ts/sdk/README.md
+++ b/ts/sdk/README.md
@@ -83,7 +83,7 @@ yarn cli manager-deposit --vault-address=<VAULT_ADDRESS> --amount=<DEPOSIT_AMOUN
 
 Make a withdraw request from a vault as the manager (`SHARES` in raw precision):
 ```
-yarn cli manager-request-withdraw --vault-address=<VAULT_ADDRESS> --amount=<SHARES>
+yarn cli manager-request-withdraw --vault-address=<VAULT_ADDRESS> --shares=<SHARES>
 ```
 
 After the redeem period has passed, the manager can complete the withdraw:


### PR DESCRIPTION
I was testing the drift-valts CLI and noticed that the documentation for manager-request-withdraw shows --amount, but shouldn't it be --shares instead?

```
yarn cli manager-request-withdraw --vault-address=<VAULT_ADDRESS> --amount=<SHARES>
```
Shouldn't the correct one be:
```
yarn cli manager-request-withdraw --vault-address=<VAULT_ADDRESS> --shares=<SHARES>
```