### PR TITLE
pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -3,7 +3,7 @@ description: "Setup Solana"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       name: Cache Solana Tool Suite
       id: cache-solana
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,16 +21,16 @@ jobs:
     name: fmt & clippy
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           profile: minimal
           override: true
           components: rustfmt, clippy
       - name: Cache build files
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
       - name: Cargo fmt
         run: cargo fmt -- --check
       - name: Cargo clippy
@@ -39,15 +39,15 @@ jobs:
     name: Unit tests
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           profile: minimal
           override: true
       - name: Cache build artefacts
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
       - name: Run package checks
         run: cargo check # run package checks
       - name: Run unit tests
@@ -55,9 +55,9 @@ jobs:
   yarn-prettier:
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '24.x.x'
           registry-url: "https://registry.npmjs.org"
@@ -68,9 +68,9 @@ jobs:
   yarn-lint:
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '24.x.x'
           registry-url: "https://registry.npmjs.org"
@@ -83,16 +83,16 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           profile: minimal
           override: true
       - name: Cache build artefacts
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
         with:
           cache-on-failure: "true"
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Cache Anchor CLI
         id: cache-anchor
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/anchor
           key: ${{ runner.os }}-anchor-cli-0.29.0
@@ -110,7 +110,7 @@ jobs:
         run: cargo install --git https://github.com/coral-xyz/anchor --tag v0.29.0 anchor-cli --locked
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '24.x.x'
           registry-url: "https://registry.npmjs.org"
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Solana Verify
         run: |
@@ -157,7 +157,7 @@ jobs:
           solana-verify build --library-name drift_vaults --base-image ellipsislabs/solana:1.16.6
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: target/deploy/drift_vaults.so

--- a/.github/workflows/on-sdk-update.yml
+++ b/.github/workflows/on-sdk-update.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '24.x.x'
           registry-url: "https://registry.npmjs.org"
@@ -56,7 +56,7 @@ jobs:
         run: rustc --version
 
       - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           profile: minimal


### PR DESCRIPTION
## Summary
- Pin every third-party action reference in `.github/workflows/main.yml`, `.github/workflows/on-sdk-update.yml`, and `.github/actions/setup-solana/action.yaml` to a full 40-char commit SHA, with the original tag kept as a trailing comment for readability.
- Removes the implicit trust placed in upstream tags (which can be moved) and protects CI from supply-chain risk if any of these action repos are compromised or retagged.
- Covers: `actions/checkout`, `actions/setup-node`, `actions/cache`, `actions/upload-artifact`, `actions-rs/toolchain`, `Swatinem/rust-cache`. SHAs were resolved live via the GitHub API at the tag each workflow currently uses; `Swatinem/rust-cache@v1` has no `v1` tag so it is pinned to the current head of the `v1` branch (which is what `@v1` resolves to today).

## Test plan
- [ ] CI runs green on this PR (workflows resolve every pinned SHA and behave identically to the previous tag-based references).