### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,28 +1,28 @@
 [source.crates-io]
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/drift-labs/drift-macros.git?rev=c57d87"]
-git = "https://github.com/drift-labs/drift-macros.git"
+[source."git+https://github.com/velocity-exchange/drift-macros.git?rev=c57d87"]
+git = "https://github.com/velocity-exchange/drift-macros.git"
 rev = "c57d87"
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/drift-labs/phoenix-v1?rev=7703c5"]
-git = "https://github.com/drift-labs/phoenix-v1"
+[source."git+https://github.com/velocity-exchange/phoenix-v1?rev=7703c5"]
+git = "https://github.com/velocity-exchange/phoenix-v1"
 rev = "7703c5"
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/drift-labs/protocol-v2.git?rev=v2.120.0"]
-git = "https://github.com/drift-labs/protocol-v2.git"
+[source."git+https://github.com/velocity-exchange/protocol-v2.git?rev=v2.120.0"]
+git = "https://github.com/velocity-exchange/protocol-v2.git"
 rev = "v2.120.0"
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/drift-labs/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729"]
-git = "https://github.com/drift-labs/pyth-crosschain"
+[source."git+https://github.com/velocity-exchange/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729"]
+git = "https://github.com/velocity-exchange/pyth-crosschain"
 rev = "3e8a24ecd0bcf22b787313e2020f4186bb22c729"
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb"]
-git = "https://github.com/drift-labs/pyth-crosschain"
+[source."git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb"]
+git = "https://github.com/velocity-exchange/pyth-crosschain"
 rev = "d790d1cb4da873a949cf33ff70349b7614b232eb"
 replace-with = "vendored-sources"
 

--- a/.github/workflows/on-sdk-update.yml
+++ b/.github/workflows/on-sdk-update.yml
@@ -87,7 +87,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${{ secrets.GH_PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/drift-labs/internal-keeper-bot/dispatches" \
+            "https://api.github.com/repos/velocity-exchange/internal-keeper-bot/dispatches" \
             -d "{\"event_type\": \"jit-sdk-update\", \"client_payload\": {
               \"sdk-version\": \"$DRIFT_SDK_VERSION\",
               \"vault-version\": \"$VAULT_VERSION\"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "drift"
 version = "2.120.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?rev=v2.120.0#f1351cdac79fe70567f77b41af1b3a334eb9f9c8"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?rev=v2.120.0#f1351cdac79fe70567f77b41af1b3a334eb9f9c8"
 dependencies = [
  "ahash 0.8.6",
  "anchor-lang",
@@ -987,7 +987,7 @@ dependencies = [
 [[package]]
 name = "drift-macros"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/drift-macros.git?rev=c57d87#c57d87e073d13d43f4d1fb09fe6822915a4ccc11"
+source = "git+https://github.com/velocity-exchange/drift-macros.git?rev=c57d87#c57d87e073d13d43f4d1fb09fe6822915a4ccc11"
 dependencies = [
  "quote",
  "syn 1.0.92",
@@ -1713,7 +1713,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "openbook-v2-light"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?rev=v2.120.0#f1351cdac79fe70567f77b41af1b3a334eb9f9c8"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?rev=v2.120.0#f1351cdac79fe70567f77b41af1b3a334eb9f9c8"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.3",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "phoenix-v1"
 version = "0.2.4"
-source = "git+https://github.com/drift-labs/phoenix-v1?rev=7703c5#7703c50cf92f2bb321dcd1e2824e1c041135ec5c"
+source = "git+https://github.com/velocity-exchange/phoenix-v1?rev=7703c5#7703c50cf92f2bb321dcd1e2824e1c041135ec5c"
 dependencies = [
  "borsh 0.10.3",
  "bytemuck",
@@ -1887,7 +1887,7 @@ checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 [[package]]
 name = "pyth-lazer-protocol"
 version = "0.1.2"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "pyth-lazer-solana-contract"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
 dependencies = [
  "anchor-lang",
  "bytemuck",
@@ -1913,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "pyth-solana-receiver-sdk"
 version = "0.3.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729#3e8a24ecd0bcf22b787313e2020f4186bb22c729"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729#3e8a24ecd0bcf22b787313e2020f4186bb22c729"
 dependencies = [
  "anchor-lang",
  "hex",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "pythnet-sdk"
 version = "2.1.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729#3e8a24ecd0bcf22b787313e2020f4186bb22c729"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729#3e8a24ecd0bcf22b787313e2020f4186bb22c729"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2882,7 +2882,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "switchboard"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?rev=v2.120.0#f1351cdac79fe70567f77b41af1b3a334eb9f9c8"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?rev=v2.120.0#f1351cdac79fe70567f77b41af1b3a334eb9f9c8"
 dependencies = [
  "anchor-lang",
 ]
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "switchboard-on-demand"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?rev=v2.120.0#f1351cdac79fe70567f77b41af1b3a334eb9f9c8"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?rev=v2.120.0#f1351cdac79fe70567f77b41af1b3a334eb9f9c8"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 soon^TM
 
-[did you see the CLI?](./ts/sdk/README.md) and the [wiki?](https://github.com/drift-labs/drift-vaults/wiki)
+[did you see the CLI?](./ts/sdk/README.md) and the [wiki?](https://github.com/velocity-exchange/drift-vaults/wiki)
 
 # Development
 

--- a/programs/drift_vaults/Cargo.toml
+++ b/programs/drift_vaults/Cargo.toml
@@ -17,10 +17,10 @@ default = []
 [dependencies]
 anchor-lang = "0.29.0"
 anchor-spl = { version = "0.29.0", features = ["metadata"] }
-drift = { git = "https://github.com/drift-labs/protocol-v2.git", rev = "v2.120.0", features = ["cpi", "mainnet-beta"] }
+drift = { git = "https://github.com/velocity-exchange/protocol-v2.git", rev = "v2.120.0", features = ["cpi", "mainnet-beta"] }
 bytemuck = { version = "1.4.0" }
 static_assertions = "1.1.0"
-drift-macros = { git = "https://github.com/drift-labs/drift-macros.git", rev = "c57d87" }
+drift-macros = { git = "https://github.com/velocity-exchange/drift-macros.git", rev = "c57d87" }
 ahash = "=0.8.6"
 serde = "=1.0.209"
 


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `github.com/drift-labs/` → `github.com/velocity-exchange/` (in `.cargo/config.toml`, `programs/drift_vaults/Cargo.toml`, `Cargo.lock`, `README.md`, `CHANGELOG.md`, `.github/workflows/on-sdk-update.yml`)
- `@drift-labs/` npm scope → `@velocity-exchange/` (in `package.json`, `ts/sdk/package.json`, all test imports under `tests/`, all SDK source imports under `ts/sdk/src/` and `ts/sdk/cli/`, `.eslintrc.js`, `yarn.lock`, `ts/sdk/yarn.lock`)

Total: 94 substitutions across 49 files.

## Skipped (upstream-Drift historical refs)

- `AUDIT.md:1`: Links to `github.com/drift-labs/audits` presenting a historical Neodyme audit of the original Drift Vaults project — this is a historical/credit reference to a separate org's audit repo, not a live dependency or this repo's own resource.

## Warning: @velocity-exchange npm scope

The `@drift-labs/sdk` dependency (used extensively in imports across tests and SDK source) and the `@drift-labs/vaults-sdk` package name have been renamed to `@velocity-exchange/sdk` and `@velocity-exchange/vaults-sdk` respectively. **Builds will break until those packages are republished under the `@velocity-exchange` npm scope.** Do not merge until `@velocity-exchange/sdk` is available on the npm registry.